### PR TITLE
Add SimpleTracer example

### DIFF
--- a/src/core/include/utils/simpletracer.h
+++ b/src/core/include/utils/simpletracer.h
@@ -1,0 +1,205 @@
+#ifndef __SIMPLE_TRACER_H__
+#define __SIMPLE_TRACER_H__
+
+//==============================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==============================================================================
+
+#include "tracing.h"
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace lbcrypto {
+
+template <typename Element>
+class SimpleFunctionTracer : public FunctionTracer<Element> {
+public:
+    SimpleFunctionTracer(const std::string& func, std::shared_ptr<std::ostream> out)
+        : m_func(func), m_out(std::move(out)) {}
+
+    ~SimpleFunctionTracer() override {
+        (*m_out) << m_func;
+        if (!m_inputs.empty()) {
+            (*m_out) << " inputs=[";
+            for (size_t i = 0; i < m_inputs.size(); ++i) {
+                if (i > 0)
+                    (*m_out) << ", ";
+                (*m_out) << m_inputs[i];
+            }
+            (*m_out) << "]";
+        }
+        if (!m_outputs.empty()) {
+            (*m_out) << " outputs=[";
+            for (size_t i = 0; i < m_outputs.size(); ++i) {
+                if (i > 0)
+                    (*m_out) << ", ";
+                (*m_out) << m_outputs[i];
+            }
+            (*m_out) << "]";
+        }
+        (*m_out) << std::endl;
+    }
+
+    void registerInput(Ciphertext<Element> ciphertext, std::string name = "") override {
+        addInput(name.empty() ? "ciphertext" : name, ciphertext.get());
+    }
+    void registerInput(ConstCiphertext<Element> ciphertext, std::string name = "") override {
+        addInput(name.empty() ? "constciphertext" : name, ciphertext.get());
+    }
+    void registerInputs(std::initializer_list<Ciphertext<Element>> ciphertexts,
+                        std::initializer_list<std::string> names = {}) override {
+        auto n = names.begin();
+        for (auto& ct : ciphertexts) {
+            std::string nm = n == names.end() ? "ciphertext" : *n;
+            if (n != names.end())
+                ++n;
+            registerInput(ct, nm);
+        }
+    }
+    void registerInputs(std::initializer_list<ConstCiphertext<Element>> ciphertexts,
+                        std::initializer_list<std::string> names = {}) override {
+        auto n = names.begin();
+        for (auto& ct : ciphertexts) {
+            std::string nm = n == names.end() ? "constciphertext" : *n;
+            if (n != names.end())
+                ++n;
+            registerInput(ct, nm);
+        }
+    }
+    void registerInput(Plaintext plaintext, std::string name = "") override {
+        addInput(name.empty() ? "plaintext" : name, plaintext.get());
+    }
+    void registerInputs(std::initializer_list<Plaintext> plaintexts,
+                        std::initializer_list<std::string> names = {}) override {
+        auto n = names.begin();
+        for (auto& pt : plaintexts) {
+            std::string nm = n == names.end() ? "plaintext" : *n;
+            if (n != names.end())
+                ++n;
+            registerInput(pt, nm);
+        }
+    }
+    void registerInput(const PublicKey<Element> key, std::string name = "") override {
+        addInput(name.empty() ? "publickey" : name, key.get());
+    }
+    void registerInput(const PrivateKey<Element> key, std::string name = "") override {
+        addInput(name.empty() ? "privatekey" : name, key.get());
+    }
+    void registerInput(const PlaintextEncodings encoding, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "encoding" : name) << "=" << int(encoding);
+        m_inputs.push_back(ss.str());
+    }
+    void registerInput(const std::vector<int64_t>& values, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "vec" : name) << "=[";
+        for (size_t i = 0; i < values.size(); ++i) {
+            if (i)
+                ss << ",";
+            ss << values[i];
+        }
+        ss << "]";
+        m_inputs.push_back(ss.str());
+    }
+    void registerInput(size_t value, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "size" : name) << "=" << value;
+        m_inputs.push_back(ss.str());
+    }
+    void registerInput(void* ptr, std::string name = "") override {
+        addInput(name.empty() ? "ptr" : name, ptr);
+    }
+
+    Ciphertext<Element> registerOutput(Ciphertext<Element> ciphertext, std::string name = "") override {
+        addOutput(name.empty() ? "ciphertext" : name, ciphertext.get());
+        return ciphertext;
+    }
+    ConstCiphertext<Element> registerOutput(ConstCiphertext<Element> ciphertext, std::string name = "") override {
+        addOutput(name.empty() ? "constciphertext" : name, ciphertext.get());
+        return ciphertext;
+    }
+    Plaintext registerOutput(Plaintext plaintext, std::string name = "") override {
+        addOutput(name.empty() ? "plaintext" : name, plaintext.get());
+        return plaintext;
+    }
+
+private:
+    void addInput(const std::string& name, const void* ptr) {
+        std::ostringstream ss;
+        ss << name << "@" << ptr;
+        m_inputs.push_back(ss.str());
+    }
+    void addOutput(const std::string& name, const void* ptr) {
+        std::ostringstream ss;
+        ss << name << "@" << ptr;
+        m_outputs.push_back(ss.str());
+    }
+
+    std::string m_func;
+    std::shared_ptr<std::ostream> m_out;
+    std::vector<std::string> m_inputs;
+    std::vector<std::string> m_outputs;
+};
+
+template <typename Element>
+class SimpleTracer : public Tracer<Element> {
+public:
+    explicit SimpleTracer(const std::string& filename = "trace.log")
+        : m_stream(std::make_shared<std::ofstream>(filename, std::ios::app)) {}
+    explicit SimpleTracer(std::shared_ptr<std::ostream> stream) : m_stream(std::move(stream)) {}
+    ~SimpleTracer() override = default;
+
+    std::unique_ptr<FunctionTracer<Element>> TraceCryptoContextEvalFunc(std::string func) override {
+        return std::make_unique<SimpleFunctionTracer<Element>>(func, m_stream);
+    }
+    std::unique_ptr<FunctionTracer<Element>> TraceCryptoContextEvalFunc(
+        std::string func, std::initializer_list<Ciphertext<Element>> ciphertexts) override {
+        auto tracer = std::make_unique<SimpleFunctionTracer<Element>>(func, m_stream);
+        tracer->registerInputs(ciphertexts);
+        return tracer;
+    }
+    std::unique_ptr<FunctionTracer<Element>> TraceCryptoContextEvalFunc(
+        std::string func, std::initializer_list<ConstCiphertext<Element>> ciphertexts) override {
+        auto tracer = std::make_unique<SimpleFunctionTracer<Element>>(func, m_stream);
+        tracer->registerInputs(ciphertexts);
+        return tracer;
+    }
+
+private:
+    std::shared_ptr<std::ostream> m_stream;
+};
+
+}  // namespace lbcrypto
+
+#endif

--- a/src/pke/examples/simple-integers-traced.cpp
+++ b/src/pke/examples/simple-integers-traced.cpp
@@ -1,0 +1,144 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+/*
+  Simple example for BFVrns (integer arithmetic)
+ */
+
+#include "openfhe.h"
+#include "utils/simpletracer.h"
+
+#include <iostream>
+#include <vector>
+
+using namespace lbcrypto;
+
+int main() {
+    // Sample Program: Step 1: Set CryptoContext
+    CCParams<CryptoContextBFVRNS> parameters;
+    parameters.SetPlaintextModulus(65537);
+    parameters.SetMultiplicativeDepth(2);
+
+    CryptoContext<DCRTPoly> cryptoContext = GenCryptoContext(parameters);
+    // Enable features that you wish to use
+    cryptoContext->Enable(PKE);
+    cryptoContext->Enable(KEYSWITCH);
+    cryptoContext->Enable(LEVELEDSHE);
+
+    IF_TRACE(cryptoContext->setTracer(std::make_shared<lbcrypto::SimpleTracer<DCRTPoly>>("simple-integers.log")));
+
+    // Sample Program: Step 2: Key Generation
+
+    // Initialize Public Key Containers
+    KeyPair<DCRTPoly> keyPair;
+
+    // Generate a public/private key pair
+    keyPair = cryptoContext->KeyGen();
+
+    // Generate the relinearization key
+    cryptoContext->EvalMultKeyGen(keyPair.secretKey);
+
+    // Generate the rotation evaluation keys
+    cryptoContext->EvalRotateKeyGen(keyPair.secretKey, {1, 2, -1, -2});
+
+    // Sample Program: Step 3: Encryption
+
+    // First plaintext vector is encoded
+    std::vector<int64_t> vectorOfInts1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    Plaintext plaintext1               = cryptoContext->MakePackedPlaintext(vectorOfInts1);
+    // Second plaintext vector is encoded
+    std::vector<int64_t> vectorOfInts2 = {3, 2, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    Plaintext plaintext2               = cryptoContext->MakePackedPlaintext(vectorOfInts2);
+    // Third plaintext vector is encoded
+    std::vector<int64_t> vectorOfInts3 = {1, 2, 5, 2, 5, 6, 7, 8, 9, 10, 11, 12};
+    Plaintext plaintext3               = cryptoContext->MakePackedPlaintext(vectorOfInts3);
+
+    // The encoded vectors are encrypted
+    auto ciphertext1 = cryptoContext->Encrypt(keyPair.publicKey, plaintext1);
+    auto ciphertext2 = cryptoContext->Encrypt(keyPair.publicKey, plaintext2);
+    auto ciphertext3 = cryptoContext->Encrypt(keyPair.publicKey, plaintext3);
+
+    // Sample Program: Step 4: Evaluation
+
+    // Homomorphic additions
+    auto ciphertextAdd12     = cryptoContext->EvalAdd(ciphertext1, ciphertext2);
+    auto ciphertextAddResult = cryptoContext->EvalAdd(ciphertextAdd12, ciphertext3);
+
+    // Homomorphic multiplications
+    auto ciphertextMul12      = cryptoContext->EvalMult(ciphertext1, ciphertext2);
+    auto ciphertextMultResult = cryptoContext->EvalMult(ciphertextMul12, ciphertext3);
+
+    // Homomorphic rotations
+    auto ciphertextRot1 = cryptoContext->EvalRotate(ciphertext1, 1);
+    auto ciphertextRot2 = cryptoContext->EvalRotate(ciphertext1, 2);
+    auto ciphertextRot3 = cryptoContext->EvalRotate(ciphertext1, -1);
+    auto ciphertextRot4 = cryptoContext->EvalRotate(ciphertext1, -2);
+
+    // Sample Program: Step 5: Decryption
+
+    // Decrypt the result of additions
+    Plaintext plaintextAddResult;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextAddResult, &plaintextAddResult);
+
+    // Decrypt the result of multiplications
+    Plaintext plaintextMultResult;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextMultResult, &plaintextMultResult);
+
+    // Decrypt the result of rotations
+    Plaintext plaintextRot1;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot1, &plaintextRot1);
+    Plaintext plaintextRot2;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot2, &plaintextRot2);
+    Plaintext plaintextRot3;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot3, &plaintextRot3);
+    Plaintext plaintextRot4;
+    cryptoContext->Decrypt(keyPair.secretKey, ciphertextRot4, &plaintextRot4);
+
+    plaintextRot1->SetLength(vectorOfInts1.size());
+    plaintextRot2->SetLength(vectorOfInts1.size());
+    plaintextRot3->SetLength(vectorOfInts1.size());
+    plaintextRot4->SetLength(vectorOfInts1.size());
+
+    std::cout << "Plaintext #1: " << plaintext1 << std::endl;
+    std::cout << "Plaintext #2: " << plaintext2 << std::endl;
+    std::cout << "Plaintext #3: " << plaintext3 << std::endl;
+
+    // Output results
+    std::cout << "\nResults of homomorphic computations" << std::endl;
+    std::cout << "#1 + #2 + #3: " << plaintextAddResult << std::endl;
+    std::cout << "#1 * #2 * #3: " << plaintextMultResult << std::endl;
+    std::cout << "Left rotation of #1 by 1: " << plaintextRot1 << std::endl;
+    std::cout << "Left rotation of #1 by 2: " << plaintextRot2 << std::endl;
+    std::cout << "Right rotation of #1 by 1: " << plaintextRot3 << std::endl;
+    std::cout << "Right rotation of #1 by 2: " << plaintextRot4 << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add example `simple-integers-traced.cpp` showing how to use `SimpleTracer`

## Testing
- `pre-commit run --files src/core/include/utils/simpletracer.h src/pke/examples/simple-integers-traced.cpp`
- `cmake -S . -B build`
- `cmake --build build --target simple-integers-traced -j` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684e0941463c8328a75a86df84929d89