### PR TITLE
Add SimpleTracer example and unique IDs

### DIFF
--- a/src/core/include/utils/simpletracer.h
+++ b/src/core/include/utils/simpletracer.h
@@ -1,0 +1,235 @@
+#ifndef __SIMPLE_TRACER_H__
+#define __SIMPLE_TRACER_H__
+
+//==============================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//==============================================================================
+
+#include "tracing.h"
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+#include <unordered_map>
+
+namespace lbcrypto {
+
+template <typename Element>
+class SimpleTracer;
+
+template <typename Element>
+class SimpleFunctionTracer : public FunctionTracer<Element> {
+public:
+    SimpleFunctionTracer(const std::string& func, std::shared_ptr<std::ostream> out, SimpleTracer<Element>* tracer)
+        : m_func(func), m_out(std::move(out)), m_tracer(tracer) {}
+
+    ~SimpleFunctionTracer() override {
+        (*m_out) << m_func;
+        if (!m_inputs.empty()) {
+            (*m_out) << " inputs=[";
+            for (size_t i = 0; i < m_inputs.size(); ++i) {
+                if (i > 0)
+                    (*m_out) << ", ";
+                (*m_out) << m_inputs[i];
+            }
+            (*m_out) << "]";
+        }
+        if (!m_outputs.empty()) {
+            (*m_out) << " outputs=[";
+            for (size_t i = 0; i < m_outputs.size(); ++i) {
+                if (i > 0)
+                    (*m_out) << ", ";
+                (*m_out) << m_outputs[i];
+            }
+            (*m_out) << "]";
+        }
+        (*m_out) << std::endl;
+    }
+
+    void registerInput(Ciphertext<Element> ciphertext, std::string name = "") override {
+        addInput(name.empty() ? "ciphertext" : name, ciphertext.get());
+    }
+    void registerInput(ConstCiphertext<Element> ciphertext, std::string name = "") override {
+        addInput(name.empty() ? "constciphertext" : name, ciphertext.get());
+    }
+    void registerInputs(std::initializer_list<Ciphertext<Element>> ciphertexts,
+                        std::initializer_list<std::string> names = {}) override {
+        auto n = names.begin();
+        for (auto& ct : ciphertexts) {
+            std::string nm = n == names.end() ? "ciphertext" : *n;
+            if (n != names.end())
+                ++n;
+            registerInput(ct, nm);
+        }
+    }
+    void registerInputs(std::initializer_list<ConstCiphertext<Element>> ciphertexts,
+                        std::initializer_list<std::string> names = {}) override {
+        auto n = names.begin();
+        for (auto& ct : ciphertexts) {
+            std::string nm = n == names.end() ? "constciphertext" : *n;
+            if (n != names.end())
+                ++n;
+            registerInput(ct, nm);
+        }
+    }
+    void registerInput(Plaintext plaintext, std::string name = "") override {
+        addInput(name.empty() ? "plaintext" : name, plaintext.get());
+    }
+    void registerInputs(std::initializer_list<Plaintext> plaintexts,
+                        std::initializer_list<std::string> names = {}) override {
+        auto n = names.begin();
+        for (auto& pt : plaintexts) {
+            std::string nm = n == names.end() ? "plaintext" : *n;
+            if (n != names.end())
+                ++n;
+            registerInput(pt, nm);
+        }
+    }
+    void registerInput(const PublicKey<Element> key, std::string name = "") override {
+        addInput(name.empty() ? "publickey" : name, key.get());
+    }
+    void registerInput(const PrivateKey<Element> key, std::string name = "") override {
+        addInput(name.empty() ? "privatekey" : name, key.get());
+    }
+    void registerInput(const PlaintextEncodings encoding, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "encoding" : name) << "=" << int(encoding);
+        m_inputs.push_back(ss.str());
+    }
+    void registerInput(const std::vector<int64_t>& values, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "vec" : name) << "=[";
+        for (size_t i = 0; i < values.size(); ++i) {
+            if (i)
+                ss << ",";
+            ss << values[i];
+        }
+        ss << "]";
+        m_inputs.push_back(ss.str());
+    }
+    void registerInput(size_t value, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "size" : name) << "=" << value;
+        m_inputs.push_back(ss.str());
+    }
+    void registerInput(void* ptr, std::string name = "") override {
+        addInput(name.empty() ? "ptr" : name, ptr);
+    }
+
+    Ciphertext<Element> registerOutput(Ciphertext<Element> ciphertext, std::string name = "") override {
+        addOutput(name.empty() ? "ciphertext" : name, ciphertext.get());
+        return ciphertext;
+    }
+    ConstCiphertext<Element> registerOutput(ConstCiphertext<Element> ciphertext, std::string name = "") override {
+        addOutput(name.empty() ? "constciphertext" : name, ciphertext.get());
+        return ciphertext;
+    }
+    Plaintext registerOutput(Plaintext plaintext, std::string name = "") override {
+        addOutput(name.empty() ? "plaintext" : name, plaintext.get());
+        return plaintext;
+    }
+
+private:
+    void addInput(const std::string& name, const void* ptr) {
+        std::ostringstream ss;
+        ss << name << "@" << m_tracer->GetId(ptr, name);
+        m_inputs.push_back(ss.str());
+    }
+    void addOutput(const std::string& name, const void* ptr) {
+        std::ostringstream ss;
+        ss << name << "@" << m_tracer->GetId(ptr, name);
+        m_outputs.push_back(ss.str());
+    }
+
+    std::string m_func;
+    std::shared_ptr<std::ostream> m_out;
+    SimpleTracer<Element>* m_tracer;
+    std::vector<std::string> m_inputs;
+    std::vector<std::string> m_outputs;
+};
+
+template <typename Element>
+class SimpleTracer : public Tracer<Element> {
+public:
+    explicit SimpleTracer(const std::string& filename = "trace.log")
+        : m_stream(std::make_shared<std::ofstream>(filename, std::ios::app)) {}
+    explicit SimpleTracer(std::shared_ptr<std::ostream> stream) : m_stream(std::move(stream)) {}
+    ~SimpleTracer() override = default;
+
+    std::unique_ptr<FunctionTracer<Element>> TraceCryptoContextEvalFunc(std::string func) override {
+        return std::make_unique<SimpleFunctionTracer<Element>>(func, m_stream, this);
+    }
+    std::unique_ptr<FunctionTracer<Element>> TraceCryptoContextEvalFunc(
+        std::string func, std::initializer_list<Ciphertext<Element>> ciphertexts) override {
+        auto tracer = std::make_unique<SimpleFunctionTracer<Element>>(func, m_stream, this);
+        tracer->registerInputs(ciphertexts);
+        return tracer;
+    }
+    std::unique_ptr<FunctionTracer<Element>> TraceCryptoContextEvalFunc(
+        std::string func, std::initializer_list<ConstCiphertext<Element>> ciphertexts) override {
+        auto tracer = std::make_unique<SimpleFunctionTracer<Element>>(func, m_stream, this);
+        tracer->registerInputs(ciphertexts);
+        return tracer;
+    }
+
+    std::string GetId(const void* ptr, const std::string& type) {
+        auto it = m_idMap.find(ptr);
+        if (it != m_idMap.end())
+            return it->second;
+
+        std::string prefix;
+        if (type.find("ciphertext") != std::string::npos)
+            prefix = "ct";
+        else if (type.find("plaintext") != std::string::npos)
+            prefix = "pt";
+        else if (type.find("publickey") != std::string::npos)
+            prefix = "pk";
+        else if (type.find("privatekey") != std::string::npos)
+            prefix = "sk";
+        else
+            prefix = "obj";
+
+        size_t id         = ++m_counters[prefix];
+        std::string value = prefix + std::to_string(id);
+        m_idMap[ptr]      = value;
+        return value;
+    }
+
+private:
+    std::shared_ptr<std::ostream> m_stream;
+    std::unordered_map<const void*, std::string> m_idMap;
+    std::unordered_map<std::string, size_t> m_counters;
+};
+
+}  // namespace lbcrypto
+
+#endif

--- a/src/pke/examples/simple-integers.cpp
+++ b/src/pke/examples/simple-integers.cpp
@@ -34,6 +34,11 @@
  */
 
 #include "openfhe.h"
+#include "utils/simpletracer.h"
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
 
 using namespace lbcrypto;
 
@@ -48,6 +53,9 @@ int main() {
     cryptoContext->Enable(PKE);
     cryptoContext->Enable(KEYSWITCH);
     cryptoContext->Enable(LEVELEDSHE);
+
+    auto tracer = std::make_shared<SimpleTracer<DCRTPoly>>("simple_integers.trace");
+    cryptoContext->setTracer(std::move(tracer));
 
     // Sample Program: Step 2: Key Generation
 

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -1400,8 +1400,8 @@ public:
    */
     Ciphertext<Element> EvalNegate(ConstCiphertext<Element> ciphertext) const {
         ValidateCiphertext(ciphertext);
-
-        return GetScheme()->EvalNegate(ciphertext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalNegate", {ciphertext}));
+        return REGISTER_IF_TRACE(GetScheme()->EvalNegate(ciphertext));
     }
 
     /**
@@ -1410,8 +1410,9 @@ public:
    */
     void EvalNegateInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalNegateInPlace", {ciphertext}));
         GetScheme()->EvalNegateInPlace(ciphertext);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     //------------------------------------------------------------------------------
@@ -1608,7 +1609,8 @@ public:
    */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element> ciphertext1, ConstCiphertext<Element> ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalSub(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSub", {ciphertext1, ciphertext2}));
+        return REGISTER_IF_TRACE(GetScheme()->EvalSub(ciphertext1, ciphertext2));
     }
 
     /**
@@ -1619,7 +1621,9 @@ public:
    */
     void EvalSubInPlace(Ciphertext<Element>& ciphertext1, ConstCiphertext<Element> ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubInPlace", {ciphertext1, ciphertext2}));
         GetScheme()->EvalSubInPlace(ciphertext1, ciphertext2);
+        IF_TRACE(t->registerOutput(ciphertext1));
     }
 
     /**
@@ -1630,7 +1634,8 @@ public:
    */
     Ciphertext<Element> EvalSubMutable(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalSubMutable(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubMutable", {ciphertext1, ciphertext2}));
+        return REGISTER_IF_TRACE(GetScheme()->EvalSubMutable(ciphertext1, ciphertext2));
     }
 
     /**
@@ -1641,7 +1646,9 @@ public:
    */
     void EvalSubMutableInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubMutableInPlace", {ciphertext1, ciphertext2}));
         GetScheme()->EvalSubMutableInPlace(ciphertext1, ciphertext2);
+        IF_TRACE(t->registerOutput(ciphertext1));
     }
 
     /**
@@ -1652,7 +1659,9 @@ public:
    */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element> ciphertext, ConstPlaintext plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalSub(ciphertext, plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSub", {ciphertext}));
+        IF_TRACE(t->registerInput(plaintext));
+        return REGISTER_IF_TRACE(GetScheme()->EvalSub(ciphertext, plaintext));
     }
 
     /**
@@ -1662,7 +1671,10 @@ public:
    * @return new ciphertext for plaintext - ciphertext
    */
     Ciphertext<Element> EvalSub(ConstPlaintext plaintext, ConstCiphertext<Element> ciphertext) const {
-        return EvalAdd(EvalNegate(ciphertext), plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSub"));
+        IF_TRACE(t->registerInput(plaintext));
+        IF_TRACE(t->registerInput(ciphertext));
+        return REGISTER_IF_TRACE(EvalAdd(EvalNegate(ciphertext), plaintext));
     }
 
     /**
@@ -1673,7 +1685,9 @@ public:
    */
     Ciphertext<Element> EvalSubMutable(Ciphertext<Element>& ciphertext, Plaintext plaintext) const {
         TypeCheck((ConstCiphertext<Element>)ciphertext, (ConstPlaintext)plaintext);
-        return GetScheme()->EvalSubMutable(ciphertext, plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubMutable", {ciphertext}));
+        IF_TRACE(t->registerInput(plaintext));
+        return REGISTER_IF_TRACE(GetScheme()->EvalSubMutable(ciphertext, plaintext));
     }
 
     /**
@@ -1683,10 +1697,13 @@ public:
    * @return new ciphertext for plaintext - ciphertext
    */
     Ciphertext<Element> EvalSubMutable(Plaintext plaintext, Ciphertext<Element>& ciphertext) const {
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubMutable"));
+        IF_TRACE(t->registerInput(plaintext));
+        IF_TRACE(t->registerInput(ciphertext));
         Ciphertext<Element> negated = EvalNegate(ciphertext);
         Ciphertext<Element> result  = EvalAddMutable(negated, plaintext);
         ciphertext                  = EvalNegate(negated);
-        return result;
+        return REGISTER_IF_TRACE(t, result);
     }
 
     /**
@@ -1696,9 +1713,11 @@ public:
    * @return new ciphertext for ciphertext - constant
    */
     Ciphertext<Element> EvalSub(ConstCiphertext<Element> ciphertext, double constant) const {
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSub", {ciphertext}));
+        IF_TRACE(t->registerInput(constant));
         Ciphertext<Element> result =
             constant >= 0 ? GetScheme()->EvalSub(ciphertext, constant) : GetScheme()->EvalAdd(ciphertext, -constant);
-        return result;
+        return REGISTER_IF_TRACE(t, result);
     }
 
     /**
@@ -1708,7 +1727,10 @@ public:
    * @return new ciphertext for constant - ciphertext
    */
     Ciphertext<Element> EvalSub(double constant, ConstCiphertext<Element> ciphertext) const {
-        return EvalAdd(EvalNegate(ciphertext), constant);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSub"));
+        IF_TRACE(t->registerInput(constant));
+        IF_TRACE(t->registerInput(ciphertext));
+        return REGISTER_IF_TRACE(t, EvalAdd(EvalNegate(ciphertext), constant));
     }
 
     /**
@@ -1718,10 +1740,16 @@ public:
    */
     void EvalSubInPlace(Ciphertext<Element>& ciphertext, double constant) const {
         if (constant >= 0) {
+            IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubInPlace", {ciphertext}));
+            IF_TRACE(t->registerInput(constant));
             GetScheme()->EvalSubInPlace(ciphertext, constant);
+            IF_TRACE(t->registerOutput(ciphertext));
         }
         else {
+            IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubInPlace", {ciphertext}));
+            IF_TRACE(t->registerInput(constant));
             GetScheme()->EvalAddInPlace(ciphertext, -constant);
+            IF_TRACE(t->registerOutput(ciphertext));
         }
     }
 
@@ -1731,8 +1759,12 @@ public:
    * @param ciphertext input ciphertext
    */
     void EvalSubInPlace(double constant, Ciphertext<Element>& ciphertext) const {
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSubInPlace"));
+        IF_TRACE(t->registerInput(constant));
+        IF_TRACE(t->registerInput(ciphertext));
         EvalNegateInPlace(ciphertext);
         EvalAddInPlace(ciphertext, constant);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     // TODO (dsuponit): commented the code below to avoid compiler errors
@@ -1786,13 +1818,14 @@ public:
    */
     Ciphertext<Element> EvalMult(ConstCiphertext<Element> ciphertext1, ConstCiphertext<Element> ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMult", {ciphertext1, ciphertext2}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext1->GetKeyTag());
         if (!evalKeyVec.size()) {
             OPENFHE_THROW("Evaluation key has not been generated for EvalMult");
         }
 
-        return GetScheme()->EvalMult(ciphertext1, ciphertext2, evalKeyVec[0]);
+        return REGISTER_IF_TRACE(GetScheme()->EvalMult(ciphertext1, ciphertext2, evalKeyVec[0]));
     }
 
     /**
@@ -1803,13 +1836,14 @@ public:
    */
     Ciphertext<Element> EvalMultMutable(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultMutable", {ciphertext1, ciphertext2}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext1->GetKeyTag());
         if (!evalKeyVec.size()) {
             OPENFHE_THROW("Evaluation key has not been generated for EvalMultMutable");
         }
 
-        return GetScheme()->EvalMultMutable(ciphertext1, ciphertext2, evalKeyVec[0]);
+        return REGISTER_IF_TRACE(GetScheme()->EvalMultMutable(ciphertext1, ciphertext2, evalKeyVec[0]));
     }
 
     /**
@@ -1819,6 +1853,7 @@ public:
    */
     void EvalMultMutableInPlace(Ciphertext<Element>& ciphertext1, Ciphertext<Element>& ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultMutableInPlace", {ciphertext1, ciphertext2}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext1->GetKeyTag());
         if (!evalKeyVec.size()) {
@@ -1826,6 +1861,7 @@ public:
         }
 
         GetScheme()->EvalMultMutableInPlace(ciphertext1, ciphertext2, evalKeyVec[0]);
+        IF_TRACE(t->registerOutput(ciphertext1));
     }
 
     /**
@@ -1835,13 +1871,14 @@ public:
    */
     Ciphertext<Element> EvalSquare(ConstCiphertext<Element> ciphertext) const {
         ValidateCiphertext(ciphertext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSquare", {ciphertext}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext->GetKeyTag());
         if (!evalKeyVec.size()) {
             OPENFHE_THROW("Evaluation key has not been generated for EvalMult");
         }
 
-        return GetScheme()->EvalSquare(ciphertext, evalKeyVec[0]);
+        return REGISTER_IF_TRACE(GetScheme()->EvalSquare(ciphertext, evalKeyVec[0]));
     }
 
     /**
@@ -1851,13 +1888,14 @@ public:
    */
     Ciphertext<Element> EvalSquareMutable(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSquareMutable", {ciphertext}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext->GetKeyTag());
         if (!evalKeyVec.size()) {
             OPENFHE_THROW("Evaluation key has not been generated for EvalMultMutable");
         }
 
-        return GetScheme()->EvalSquareMutable(ciphertext, evalKeyVec[0]);
+        return REGISTER_IF_TRACE(GetScheme()->EvalSquareMutable(ciphertext, evalKeyVec[0]));
     }
 
     /**
@@ -1867,6 +1905,7 @@ public:
    */
     void EvalSquareInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalSquareInPlace", {ciphertext}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext->GetKeyTag());
         if (!evalKeyVec.size()) {
@@ -1874,6 +1913,7 @@ public:
         }
 
         GetScheme()->EvalSquareInPlace(ciphertext, evalKeyVec[0]);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     /**
@@ -1885,7 +1925,8 @@ public:
     Ciphertext<Element> EvalMultNoRelin(ConstCiphertext<Element> ciphertext1,
                                         ConstCiphertext<Element> ciphertext2) const {
         TypeCheck(ciphertext1, ciphertext2);
-        return GetScheme()->EvalMult(ciphertext1, ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultNoRelin", {ciphertext1, ciphertext2}));
+        return REGISTER_IF_TRACE(GetScheme()->EvalMult(ciphertext1, ciphertext2));
     }
 
     /**
@@ -1897,6 +1938,7 @@ public:
         // input parameter check
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Relinearize", {ciphertext}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext->GetKeyTag());
 
@@ -1906,7 +1948,7 @@ public:
                 "keys for EvalMult");
         }
 
-        return GetScheme()->Relinearize(ciphertext, evalKeyVec);
+        return REGISTER_IF_TRACE(GetScheme()->Relinearize(ciphertext, evalKeyVec));
     }
 
     /**
@@ -1917,6 +1959,7 @@ public:
         // input parameter check
         if (!ciphertext)
             OPENFHE_THROW("Input ciphertext is nullptr");
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("RelinearizeInPlace", {ciphertext}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext->GetKeyTag());
         if (evalKeyVec.size() < (ciphertext->NumberCiphertextElements() - 2)) {
@@ -1926,6 +1969,7 @@ public:
         }
 
         GetScheme()->RelinearizeInPlace(ciphertext, evalKeyVec);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     /**
@@ -1939,6 +1983,7 @@ public:
         // input parameter check
         if (!ciphertext1 || !ciphertext2)
             OPENFHE_THROW("Input ciphertext is nullptr");
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultAndRelinearize", {ciphertext1, ciphertext2}));
 
         const auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext1->GetKeyTag());
 
@@ -1949,7 +1994,7 @@ public:
                 "keys for EvalMult");
         }
 
-        return GetScheme()->EvalMultAndRelinearize(ciphertext1, ciphertext2, evalKeyVec);
+        return REGISTER_IF_TRACE(GetScheme()->EvalMultAndRelinearize(ciphertext1, ciphertext2, evalKeyVec));
     }
 
     /**
@@ -1960,7 +2005,9 @@ public:
    */
     Ciphertext<Element> EvalMult(ConstCiphertext<Element> ciphertext, ConstPlaintext plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalMult(ciphertext, plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMult", {ciphertext}));
+        IF_TRACE(t->registerInput(plaintext));
+        return REGISTER_IF_TRACE(GetScheme()->EvalMult(ciphertext, plaintext));
     }
 
     /**
@@ -1970,7 +2017,10 @@ public:
    * @return the result of multiplication
    */
     Ciphertext<Element> EvalMult(ConstPlaintext plaintext, ConstCiphertext<Element> ciphertext) const {
-        return EvalMult(ciphertext, plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMult"));
+        IF_TRACE(t->registerInput(plaintext));
+        IF_TRACE(t->registerInput(ciphertext));
+        return REGISTER_IF_TRACE(EvalMult(ciphertext, plaintext));
     }
 
     /**
@@ -1981,7 +2031,9 @@ public:
    */
     Ciphertext<Element> EvalMultMutable(Ciphertext<Element>& ciphertext, Plaintext plaintext) const {
         TypeCheck(ciphertext, plaintext);
-        return GetScheme()->EvalMultMutable(ciphertext, plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultMutable", {ciphertext}));
+        IF_TRACE(t->registerInput(plaintext));
+        return REGISTER_IF_TRACE(GetScheme()->EvalMultMutable(ciphertext, plaintext));
     }
 
     /**
@@ -1991,7 +2043,10 @@ public:
    * @return the result of multiplication
    */
     Ciphertext<Element> EvalMultMutable(Plaintext plaintext, Ciphertext<Element>& ciphertext) const {
-        return EvalMultMutable(ciphertext, plaintext);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultMutable"));
+        IF_TRACE(t->registerInput(plaintext));
+        IF_TRACE(t->registerInput(ciphertext));
+        return REGISTER_IF_TRACE(EvalMultMutable(ciphertext, plaintext));
     }
 
     // template <typename T = const NativeInteger,
@@ -2034,7 +2089,9 @@ public:
         if (!ciphertext) {
             OPENFHE_THROW("Input ciphertext is nullptr");
         }
-        return GetScheme()->EvalMult(ciphertext, constant);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMult", {ciphertext}));
+        IF_TRACE(t->registerInput(constant));
+        return REGISTER_IF_TRACE(GetScheme()->EvalMult(ciphertext, constant));
     }
 
     /**
@@ -2056,8 +2113,10 @@ public:
         if (!ciphertext) {
             OPENFHE_THROW("Input ciphertext is nullptr");
         }
-
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalMultInPlace", {ciphertext}));
+        IF_TRACE(t->registerInput(constant));
         GetScheme()->EvalMultInPlace(ciphertext, constant);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     /**
@@ -2177,9 +2236,10 @@ public:
    */
     Ciphertext<Element> EvalRotate(ConstCiphertext<Element> ciphertext, int32_t index) const {
         ValidateCiphertext(ciphertext);
-
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalRotate", {ciphertext}));
+        IF_TRACE(t->registerInput(static_cast<size_t>(index), "index"));
         auto evalKeyMap = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
-        return GetScheme()->EvalAtIndex(ciphertext, index, evalKeyMap);
+        return REGISTER_IF_TRACE(GetScheme()->EvalAtIndex(ciphertext, index, evalKeyMap));
     }
 
     /**
@@ -2369,13 +2429,14 @@ public:
                                          ConstCiphertext<Element> ciphertext2) const {
         ValidateCiphertext(ciphertext1);
         ValidateCiphertext(ciphertext2);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("ComposedEvalMult", {ciphertext1, ciphertext2}));
 
         auto evalKeyVec = CryptoContextImpl<Element>::GetEvalMultKeyVector(ciphertext1->GetKeyTag());
         if (!evalKeyVec.size()) {
             OPENFHE_THROW("Evaluation key has not been generated for EvalMult");
         }
 
-        return GetScheme()->ComposedEvalMult(ciphertext1, ciphertext2, evalKeyVec[0]);
+        return REGISTER_IF_TRACE(GetScheme()->ComposedEvalMult(ciphertext1, ciphertext2, evalKeyVec[0]));
     }
 
     /**
@@ -2387,8 +2448,8 @@ public:
    */
     Ciphertext<Element> Rescale(ConstCiphertext<Element> ciphertext) const {
         ValidateCiphertext(ciphertext);
-
-        return GetScheme()->ModReduce(ciphertext, BASE_NUM_LEVELS_TO_DROP);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Rescale", {ciphertext}));
+        return REGISTER_IF_TRACE(GetScheme()->ModReduce(ciphertext, BASE_NUM_LEVELS_TO_DROP));
     }
 
     /**
@@ -2399,8 +2460,9 @@ public:
    */
     void RescaleInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("RescaleInPlace", {ciphertext}));
         GetScheme()->ModReduceInPlace(ciphertext, BASE_NUM_LEVELS_TO_DROP);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     /**
@@ -2410,8 +2472,8 @@ public:
    */
     Ciphertext<Element> ModReduce(ConstCiphertext<Element> ciphertext) const {
         ValidateCiphertext(ciphertext);
-
-        return GetScheme()->ModReduce(ciphertext, BASE_NUM_LEVELS_TO_DROP);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("ModReduce", {ciphertext}));
+        return REGISTER_IF_TRACE(GetScheme()->ModReduce(ciphertext, BASE_NUM_LEVELS_TO_DROP));
     }
 
     /**
@@ -2420,8 +2482,9 @@ public:
    */
     void ModReduceInPlace(Ciphertext<Element>& ciphertext) const {
         ValidateCiphertext(ciphertext);
-
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("ModReduceInPlace", {ciphertext}));
         GetScheme()->ModReduceInPlace(ciphertext, BASE_NUM_LEVELS_TO_DROP);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
 
     /**
@@ -2433,8 +2496,9 @@ public:
     Ciphertext<Element> LevelReduce(ConstCiphertext<Element> ciphertext, const EvalKey<Element> evalKey,
                                     size_t levels = 1) const {
         ValidateCiphertext(ciphertext);
-
-        return GetScheme()->LevelReduce(ciphertext, evalKey, levels);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("LevelReduce", {ciphertext}));
+        IF_TRACE(t->registerInput(static_cast<size_t>(levels), "levels"));
+        return REGISTER_IF_TRACE(GetScheme()->LevelReduce(ciphertext, evalKey, levels));
     }
 
     /**
@@ -2447,7 +2511,10 @@ public:
         if (levels <= 0) {
             return;
         }
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("LevelReduceInPlace", {ciphertext}));
+        IF_TRACE(t->registerInput(static_cast<size_t>(levels), "levels"));
         GetScheme()->LevelReduceInPlace(ciphertext, evalKey, levels);
+        IF_TRACE(t->registerOutput(ciphertext));
     }
     /**
    * Compress - Reduces the size of ciphertext modulus to minimize the
@@ -2460,8 +2527,9 @@ public:
     Ciphertext<Element> Compress(ConstCiphertext<Element> ciphertext, uint32_t towersLeft = 1) const {
         if (ciphertext == nullptr)
             OPENFHE_THROW("input ciphertext is invalid (has no data)");
-
-        return GetScheme()->Compress(ciphertext, towersLeft);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Compress", {ciphertext}));
+        IF_TRACE(t->registerInput(static_cast<size_t>(towersLeft), "towersLeft"));
+        return REGISTER_IF_TRACE(GetScheme()->Compress(ciphertext, towersLeft));
     }
 
     //------------------------------------------------------------------------------
@@ -2480,11 +2548,14 @@ public:
         if (!ciphertextVec.size())
             OPENFHE_THROW("Empty input ciphertext vector");
 
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalAddMany"));
+        for (const auto& ct : ciphertextVec)
+            IF_TRACE(t->registerInput(ct));
         if (ciphertextVec.size() == 1) {
-            return ciphertextVec[0];
+            return REGISTER_IF_TRACE(t, ciphertextVec[0]);
         }
 
-        return GetScheme()->EvalAddMany(ciphertextVec);
+        return REGISTER_IF_TRACE(t, GetScheme()->EvalAddMany(ciphertextVec));
     }
 
     /**
@@ -2501,8 +2572,12 @@ public:
         // input parameter check
         if (!ciphertextVec.size())
             OPENFHE_THROW("Empty input ciphertext vector");
-
-        return GetScheme()->EvalAddManyInPlace(ciphertextVec);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalAddManyInPlace"));
+        for (const auto& ct : ciphertextVec)
+            IF_TRACE(t->registerInput(ct));
+        auto result = GetScheme()->EvalAddManyInPlace(ciphertextVec);
+        IF_TRACE(t->registerOutput(result));
+        return result;
     }
 
     /**

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -64,6 +64,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 #include <algorithm>
 #include <unordered_map>
 #include <set>
@@ -1243,6 +1244,10 @@ public:
    * @return ciphertext (or null on failure)
    */
     Ciphertext<Element> Encrypt(const Plaintext& plaintext, const PublicKey<Element> publicKey) const {
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Encrypt"));
+        IF_TRACE(t->registerInput(plaintext));
+        IF_TRACE(t->registerInput(publicKey));
+
         if (plaintext == nullptr)
             OPENFHE_THROW("Input plaintext is nullptr");
         ValidateKey(publicKey);
@@ -1258,7 +1263,7 @@ public:
             ciphertext->SetSlots(plaintext->GetSlots());
         }
 
-        return ciphertext;
+        return REGISTER_IF_TRACE(ciphertext);
     }
 
     /**
@@ -1268,7 +1273,10 @@ public:
    * @return ciphertext (or null on failure)
    */
     Ciphertext<Element> Encrypt(const PublicKey<Element> publicKey, Plaintext plaintext) const {
-        return Encrypt(plaintext, publicKey);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Encrypt"));
+        IF_TRACE(t->registerInput(publicKey));
+        IF_TRACE(t->registerInput(plaintext));
+        return REGISTER_IF_TRACE(Encrypt(plaintext, publicKey));
     }
 
     /**
@@ -1278,6 +1286,10 @@ public:
    * @return ciphertext (or null on failure)
    */
     Ciphertext<Element> Encrypt(const Plaintext& plaintext, const PrivateKey<Element> privateKey) const {
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Encrypt"));
+        IF_TRACE(t->registerInput(plaintext));
+        IF_TRACE(t->registerInput(privateKey));
+
         //    if (plaintext == nullptr)
         //      OPENFHE_THROW( "Input plaintext is nullptr");
         ValidateKey(privateKey);
@@ -1293,7 +1305,7 @@ public:
             ciphertext->SetSlots(plaintext->GetSlots());
         }
 
-        return ciphertext;
+        return REGISTER_IF_TRACE(ciphertext);
     }
 
     /**
@@ -1303,7 +1315,10 @@ public:
    * @return ciphertext (or null on failure)
    */
     Ciphertext<Element> Encrypt(const PrivateKey<Element> privateKey, Plaintext plaintext) const {
-        return Encrypt(plaintext, privateKey);
+        IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("Encrypt"));
+        IF_TRACE(t->registerInput(privateKey));
+        IF_TRACE(t->registerInput(plaintext));
+        return REGISTER_IF_TRACE(Encrypt(plaintext, privateKey));
     }
 
     /**


### PR DESCRIPTION
## Summary
- give `SimpleTracer` unique ids so traces show `pt1`, `ct1`, etc
- trace the `simple-integers` example using `SimpleTracer`

## Testing
- `pre-commit run --files src/core/include/utils/simpletracer.h src/pke/examples/simple-integers.cpp`
- `cmake -S . -B build`
- `cmake --build build --target simple-integers -- -j` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684e0941463c8328a75a86df84929d89