### PR TITLE
Fix negative rotation index logging

### DIFF
--- a/src/core/include/utils/simpletracer.h
+++ b/src/core/include/utils/simpletracer.h
@@ -136,6 +136,11 @@ public:
         ss << "]";
         m_inputs.push_back(ss.str());
     }
+    void registerInput(double value, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "double" : name) << "=" << value;
+        m_inputs.push_back(ss.str());
+    }
     void registerInput(int64_t value, std::string name = "") override {
         std::ostringstream ss;
         ss << (name.empty() ? "int" : name) << "=" << value;

--- a/src/core/include/utils/simpletracer.h
+++ b/src/core/include/utils/simpletracer.h
@@ -136,6 +136,11 @@ public:
         ss << "]";
         m_inputs.push_back(ss.str());
     }
+    void registerInput(int64_t value, std::string name = "") override {
+        std::ostringstream ss;
+        ss << (name.empty() ? "int" : name) << "=" << value;
+        m_inputs.push_back(ss.str());
+    }
     void registerInput(size_t value, std::string name = "") override {
         std::ostringstream ss;
         ss << (name.empty() ? "size" : name) << "=" << value;

--- a/src/core/include/utils/tracing.h
+++ b/src/core/include/utils/tracing.h
@@ -66,6 +66,7 @@ struct FunctionTracer {
     virtual void registerInput(const PrivateKey<Element> privateKey, std::string name = "") = 0;
     virtual void registerInput(const PlaintextEncodings encoding, std::string name = "")    = 0;
     virtual void registerInput(const std::vector<int64_t>& values, std::string name = "")   = 0;
+    virtual void registerInput(int64_t value, std::string name = "")                        = 0;
     virtual void registerInput(size_t value, std::string name = "")                         = 0;
 
     /// If there are unknown types that should be traced, they should be registered here.
@@ -111,6 +112,7 @@ public:
     virtual void registerInput(const PrivateKey<Element>, std::string) override {}
     virtual void registerInput(const PlaintextEncodings, std::string) override {}
     virtual void registerInput(const std::vector<int64_t>&, std::string) override {}
+    virtual void registerInput(int64_t, std::string) override {}
     virtual void registerInput(size_t, std::string) override {}
     virtual void registerInput(void*, std::string) override {}
 

--- a/src/core/include/utils/tracing.h
+++ b/src/core/include/utils/tracing.h
@@ -66,8 +66,12 @@ struct FunctionTracer {
     virtual void registerInput(const PrivateKey<Element> privateKey, std::string name = "") = 0;
     virtual void registerInput(const PlaintextEncodings encoding, std::string name = "")    = 0;
     virtual void registerInput(const std::vector<int64_t>& values, std::string name = "")   = 0;
-    virtual void registerInput(int64_t value, std::string name = "")                        = 0;
-    virtual void registerInput(size_t value, std::string name = "")                         = 0;
+    virtual void registerInput(double value, std::string name = "")                         = 0;
+    virtual void registerInput(int32_t value, std::string name = "") {
+        registerInput(static_cast<int64_t>(value), name);
+    }
+    virtual void registerInput(int64_t value, std::string name = "") = 0;
+    virtual void registerInput(size_t value, std::string name = "")  = 0;
 
     /// If there are unknown types that should be traced, they should be registered here.
     virtual void registerInput(void* ptr, std::string name = "") = 0;
@@ -112,6 +116,7 @@ public:
     virtual void registerInput(const PrivateKey<Element>, std::string) override {}
     virtual void registerInput(const PlaintextEncodings, std::string) override {}
     virtual void registerInput(const std::vector<int64_t>&, std::string) override {}
+    virtual void registerInput(double, std::string) override {}
     virtual void registerInput(int64_t, std::string) override {}
     virtual void registerInput(size_t, std::string) override {}
     virtual void registerInput(void*, std::string) override {}

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -2237,7 +2237,7 @@ public:
     Ciphertext<Element> EvalRotate(ConstCiphertext<Element> ciphertext, int32_t index) const {
         ValidateCiphertext(ciphertext);
         IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalRotate", {ciphertext}));
-        IF_TRACE(t->registerInput(static_cast<int64_t>(index), "index"));
+        IF_TRACE(t->registerInput(index, "index"));
         auto evalKeyMap = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
         return REGISTER_IF_TRACE(GetScheme()->EvalAtIndex(ciphertext, index, evalKeyMap));
     }

--- a/src/pke/include/cryptocontext.h
+++ b/src/pke/include/cryptocontext.h
@@ -2237,7 +2237,7 @@ public:
     Ciphertext<Element> EvalRotate(ConstCiphertext<Element> ciphertext, int32_t index) const {
         ValidateCiphertext(ciphertext);
         IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalRotate", {ciphertext}));
-        IF_TRACE(t->registerInput(static_cast<size_t>(index), "index"));
+        IF_TRACE(t->registerInput(static_cast<int64_t>(index), "index"));
         auto evalKeyMap = CryptoContextImpl<Element>::GetEvalAutomorphismKeyMap(ciphertext->GetKeyTag());
         return REGISTER_IF_TRACE(GetScheme()->EvalAtIndex(ciphertext, index, evalKeyMap));
     }

--- a/src/pke/lib/cryptocontext.cpp
+++ b/src/pke/lib/cryptocontext.cpp
@@ -413,7 +413,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalAtIndex(ConstCiphertext<Elem
     ValidateCiphertext(ciphertext);
 
     IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalAtIndex", {ciphertext}));
-    IF_TRACE(t->registerInput(static_cast<size_t>(index), "index"));
+    IF_TRACE(t->registerInput(static_cast<int64_t>(index), "index"));
     // If the index is zero, no rotation is needed, copy the ciphertext and return
     // This is done after the keyMap so that it is protected if there's not a valid key.
     if (0 == index) {

--- a/src/pke/lib/cryptocontext.cpp
+++ b/src/pke/lib/cryptocontext.cpp
@@ -413,7 +413,7 @@ Ciphertext<Element> CryptoContextImpl<Element>::EvalAtIndex(ConstCiphertext<Elem
     ValidateCiphertext(ciphertext);
 
     IF_TRACE(auto t = m_tracer->TraceCryptoContextEvalFunc("EvalAtIndex", {ciphertext}));
-    IF_TRACE(t->registerInput(static_cast<int64_t>(index), "index"));
+    IF_TRACE(t->registerInput(index, "index"));
     // If the index is zero, no rotation is needed, copy the ciphertext and return
     // This is done after the keyMap so that it is protected if there's not a valid key.
     if (0 == index) {


### PR DESCRIPTION
## Summary
- support logging of signed integers in tracer
- record EvalRotate index as signed

## Testing
- `cpplint src/core/include/utils/tracing.h src/core/include/utils/simpletracer.h src/pke/include/cryptocontext.h src/pke/lib/cryptocontext.cpp`

------
https://chatgpt.com/codex/tasks/task_e_684f43d8ea4883288bcf9d4e3fc235a0