### PR TITLE
Fix ambiguous overload with TracingSharedPtr

### DIFF
--- a/src/core/include/utils/tracingsharedptr.h
+++ b/src/core/include/utils/tracingsharedptr.h
@@ -1,11 +1,43 @@
 #ifndef __TRACINGSHAREDPTR_H__
 #define __TRACINGSHAREDPTR_H__
 
+//=============================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2022, NJIT, Duality Technologies Inc. and other contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #include "config_core.h"
 
+#include <memory>
+#include <utility>
+#include <type_traits>
+
 #ifdef ENABLE_TRACER_SUPPORT
-    #include <memory>
-    #include <utility>
     #include "cryptocontext.h"
 
 namespace lbcrypto {
@@ -39,25 +71,25 @@ public:
         trace("rawptr-ctor");
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr(const std::shared_ptr<U>& other)  // NOLINT(runtime/explicit)
         : Base(other) {
         trace("copy-ctor");
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr(std::shared_ptr<U>&& other)  // NOLINT(runtime/explicit)
         : Base(std::move(other)) {
         trace("move-ctor");
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr(const TracingSharedPtr<U>& other)  // NOLINT(runtime/explicit)
         : Base(other) {
         trace("copy-ctor");
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr(TracingSharedPtr<U>&& other)  // NOLINT(runtime/explicit)
         : Base(std::move(other)) {
         trace("move-ctor");
@@ -83,28 +115,28 @@ public:
         return *this;
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr& operator=(const TracingSharedPtr<U>& other) {
         Base::operator=(other);
         trace("copy-assign");
         return *this;
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr& operator=(TracingSharedPtr<U>&& other) {
         Base::operator=(std::move(other));
         trace("move-assign");
         return *this;
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr& operator=(const std::shared_ptr<U>& other) {
         Base::operator=(other);
         trace("assign");
         return *this;
     }
 
-    template <class U>
+    template <class U, typename = std::enable_if_t<std::is_convertible<U*, T*>::value>>
     TracingSharedPtr& operator=(std::shared_ptr<U>&& other) {
         Base::operator=(std::move(other));
         trace("move-assign2");


### PR DESCRIPTION
## Summary
- add missing license header
- constrain TracingSharedPtr constructors and operators to only accept compatible pointer types
- include required headers unconditionally

## Testing
- `pre-commit run --files src/core/include/utils/tracingsharedptr.h`

------
https://chatgpt.com/codex/tasks/task_e_6854b52011d08328a8353bcccbea962f